### PR TITLE
Use binary from `POCKET_IC_BIN` if set

### DIFF
--- a/packages/pic/src/pocket-ic-server.ts
+++ b/packages/pic/src/pocket-ic-server.ts
@@ -49,7 +49,7 @@ export class PocketIcServer {
   }
 
   private static getBinPath(): string {
-    return resolve(__dirname, '..', 'pocket-ic');
+    return process.env['POCKET_IC_BIN'] || resolve(__dirname, '..', 'pocket-ic');
   }
 
   private static async assertBinExists(binPath: string): Promise<void> {


### PR DESCRIPTION
Hi. I'm currently adding toolchain version management to mops (moc, wasmtime, pocket-ic)

And I want to use pic-js with custom `POCKET_IC_BIN` to run specified version of pocket-ic. 