### PR TITLE
fix: client refuses to start on MacOS ARM chips that are also running…

### DIFF
--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  lint:
+  test_bun:
     name: Test (Bun)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  lint:
+  test_nodejs:
     name: Test (NodeJS)
     runs-on: ubuntu-latest
     steps:

--- a/packages/pic/src/error.ts
+++ b/packages/pic/src/error.ts
@@ -1,7 +1,26 @@
-export class PlatformMismatchError extends Error {
-  constructor() {
+export class BinStartError extends Error {
+  constructor(cause: Error) {
     super(
-      `The PocketIC binary is only available for x64 Linux and Intel/rosetta-enabled Darwin, but you are running ${process.platform} ${process.arch}.`,
+      `There was an error starting the PocketIC Binary.
+
+Original error: ${cause.name} ${cause.message}.
+${cause.stack}`,
+      { cause },
+    );
+  }
+}
+
+export class BinStartMacOSArmError extends Error {
+  constructor(cause: Error) {
+    super(
+      `There was an error starting the PocketIC Binary.
+
+It seems you are running on an Apple Silicon Mac. The PocketIC binary can not run with the ARM architecture on Apple Silicon Macs.
+Please install and enable Rosetta if it is not enabled and try again.
+
+Original error: ${cause.name} ${cause.message}.
+${cause.stack}`,
+      { cause },
     );
   }
 }
@@ -9,7 +28,7 @@ export class PlatformMismatchError extends Error {
 export class BinNotFoundError extends Error {
   constructor(picBinPath: string) {
     super(
-      `Could not find the PocketIC binary. The PocketIC binary could not be found at ${picBinPath}. Please try install @hadronous/pic again.`,
+      `Could not find the PocketIC binary. The PocketIC binary could not be found at ${picBinPath}. Please try installing @hadronous/pic again.`,
     );
   }
 }

--- a/packages/pic/src/pocket-ic.ts
+++ b/packages/pic/src/pocket-ic.ts
@@ -1,6 +1,6 @@
 import { Principal } from '@dfinity/principal';
 import { IDL } from '@dfinity/candid';
-import { assertPlatform, optionalBigInt, readFileAsBytes } from './util';
+import { optionalBigInt, readFileAsBytes } from './util';
 import { PocketIcServer } from './pocket-ic-server';
 import { PocketIcClient } from './pocket-ic-client';
 import { ActorInterface, Actor, createActorClass } from './pocket-ic-actor';
@@ -72,8 +72,6 @@ export class PocketIc {
    * ```
    */
   public static async create(): Promise<PocketIc> {
-    assertPlatform();
-
     const server = await PocketIcServer.start();
     const client = await PocketIcClient.create(server.getUrl());
 
@@ -95,8 +93,6 @@ export class PocketIc {
    * ```
    */
   public static async createFromUrl(url: string): Promise<PocketIc> {
-    assertPlatform();
-
     const client = await PocketIcClient.create(url);
     return new PocketIc(client);
   }

--- a/packages/pic/src/util/os.ts
+++ b/packages/pic/src/util/os.ts
@@ -1,5 +1,3 @@
-import { PlatformMismatchError } from '../error';
-
 export function is64Bit(): boolean {
   return process.arch === 'x64';
 }
@@ -12,12 +10,6 @@ export function isDarwin(): boolean {
   return process.platform === 'darwin';
 }
 
-function isCorrectPlatform(): boolean {
-  return is64Bit() && (isLinux() || isDarwin());
-}
-
-export function assertPlatform() {
-  if (!isCorrectPlatform()) {
-    throw new PlatformMismatchError();
-  }
+export function isArm(): boolean {
+  return process.arch === 'arm64';
 }


### PR DESCRIPTION
… NodeJS on ARM architecture

wait for an exception to be thrown and show info about Rosetta if the platform/arch is macos/arm64